### PR TITLE
Change identifiers items from jsonPointer to list of jsonPointers

### DIFF
--- a/src/main/resources/examples/resource/initech.tps.report.v1.json
+++ b/src/main/resources/examples/resource/initech.tps.report.v1.json
@@ -61,6 +61,6 @@
         "/properties/tps_code"
     ],
     "identifiers": [
-        "/properties/tps_code"
+        ["/properties/tps_code"]
     ]
 }

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -286,7 +286,7 @@
         "identifiers": {
             "description": "A list of identifiers. An identifier is a list of JSON pointers to properties that uniquely identify the resource. An identifier can be a single or multiple properties.",
             "type": "array",
-            "minItems": "1",
+            "minItems": 1,
             "items": {
                 "$ref": "#/definitions/jsonPointerArray"
             }

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -21,7 +21,7 @@
     "/properties/propertyB"
   ],
   "identifiers": [
-    "/properties/propertyA"
+    ["/properties/propertyA"]
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/81

*Description of changes:* This changes the structure for identifiers so that compound identifiers are valid. Previously, only single property identifiers were valid.
Before:
```
{
...
    "identifiers": {
        "#/properties/identifier1"
    }
}
```
In the above schema, if two resource properties `identifier2a` and `identifier2b` together uniquely identify a resource, there is no way of expressing that with a single JSON pointer. The proposed change allows for that and is also in line with what CloudFormation is expecting when pulling down schemas.

Now:
```
{
...
    "identifiers": {
        ["#/properties/identifier1"],
        ["#/properties/identifier2a", "#/properties/identifier2b"] 
    }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
