### PR TITLE
Require description, allow documentationUrl, update sourceUrl

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -214,12 +214,20 @@
             "$ref": "https://json-schema.org/draft-07/schema#/properties/title"
         },
         "description": {
+            "$comment": "A short description of the resource provider. This will be shown in the AWS CloudFormation console.",
             "$ref": "https://json-schema.org/draft-07/schema#/properties/description"
         },
         "sourceUrl": {
-            "$comment": "Source Code Location (e.g; .git URL)",
+            "$comment": "The location of the source code for this resource provider, to help interested parties submit issues or improvements.",
             "examples": [
-                "git@github.com:awslabs/aws-cloudformation-rpdk.git"
+                "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-s3"
+            ],
+            "type": "string"
+        },
+        "documentationUrl": {
+            "$comment": "A page with supplemental documentation. The property documentation in schemas should be able to stand alone, but this is an opportunity for e.g. rich examples or more guided documents.",
+            "examples": [
+                "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/CHAP_Using.html"
             ],
             "type": "string"
         },
@@ -245,8 +253,7 @@
                     "$ref": "#/definitions/properties"
                 }
             },
-            "additionalProperties": false,
-            "minProperties": 1
+            "additionalProperties": false
         },
         "remote": {
             "description": "Reserved for CloudFormation use. A namespace to inline remote schemas.",
@@ -310,7 +317,8 @@
     },
     "required": [
         "typeName",
-        "properties"
+        "properties",
+        "description"
     ],
     "additionalProperties": false
 }

--- a/src/test/java/com/aws/cfn/resource/ValidatorTest.java
+++ b/src/test/java/com/aws/cfn/resource/ValidatorTest.java
@@ -16,7 +16,9 @@ public class ValidatorTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";
     private static final String TYPE_NAME_KEY = "typeName";
     private static final String PROPERTIES_KEY = "properties";
+    private static final String DESCRIPTION_KEY = "description";
     private static final String EXAMPLE_TYPE_NAME = "Organization::Service::Resource";
+    private static final String EXAMPLE_DESCRIPTION = "description";
 
     @Test
     public void validateObject_validObject_shouldNotThrow() {
@@ -120,6 +122,7 @@ public class ValidatorTest {
         final Validator validator = new Validator();
         final JSONObject definition = new JSONObject()
                 .put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
+                .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION)
                 .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject()));
         validator.validateResourceDefinition(definition);
     }
@@ -135,7 +138,8 @@ public class ValidatorTest {
     public void validateDefinition_invalidDefinitionNoPropertiesKey_shouldThrow() {
         final Validator validator = new Validator();
         final JSONObject definition = new JSONObject()
-                .put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME);
+                .put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
+                .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION);
         try {
             validator.validateResourceDefinition(definition);
         } catch (final ValidationException e) {
@@ -148,10 +152,28 @@ public class ValidatorTest {
     }
 
     @Test
+    public void validateDefinition_invalidDefinitionNoDescriptionKey_shouldThrow() {
+        final Validator validator = new Validator();
+        final JSONObject definition = new JSONObject()
+                .put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
+                .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject()));
+        try {
+            validator.validateResourceDefinition(definition);
+        } catch (final ValidationException e) {
+            assertThat(e.getCausingExceptions(), hasSize(0));
+            assertThat(
+                    e.getMessage(),
+                    is("#: required key [description] not found")
+            );
+        }
+    }
+
+    @Test
     public void validateDefinition_invalidDefinitionNoProperties_shouldThrow() {
         final Validator validator = new Validator();
         final JSONObject definition = new JSONObject()
                 .put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
+                .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION)
                 .put(PROPERTIES_KEY, new JSONObject());
         try {
             validator.validateResourceDefinition(definition);

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -1,5 +1,6 @@
 {
   "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
   "properties": {
     "propertyA": {
       "type": "string"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

* Added comment to `description`, require it be present so the console can rely descriptions
* Updated `sourceUrl` example and comment
* Added `documentationUrl` property, to allow it to be stored in code/versioned/etc - otherwise it's an API parameter that's hard to track
* Remove `minProperties` from `definitions`, so an empty definitions block is valid. I believe this was added to try and "nudge" people to use definitions, but it's unnecessary and can be annoying.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
