### PR TITLE
Adds handlers section to meta schema

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -4,6 +4,24 @@
     "title": "CloudFormation Resource Provider Definition MetaSchema",
     "description": "This schema validates a CloudFormation resource provider definition.",
     "definitions": {
+        "handlerDefinition": {
+            "description": "Defines any execution operations which can be performed on this resource provider",
+            "type": "object",
+            "properties": {
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "additionalItems": false
+                }
+            },
+            "additionalItems": false,
+            "required": [
+                "permissions"
+            ]
+        },
         "jsonPointerArray": {
             "type": "array",
             "minItems": 1,
@@ -251,6 +269,28 @@
             "patternProperties": {
                 "^[A-Za-z0-9]{1,64}$": {
                     "$ref": "#/definitions/properties"
+                }
+            },
+            "additionalProperties": false
+        },
+        "handlers": {
+            "description": "Defines the provisioning operations which can be performed on this resource type",
+            "type": "object",
+            "properties": {
+                "create": {
+                    "$ref": "#/definitions/handlerDefinition"
+                },
+                "read": {
+                    "$ref": "#/definitions/handlerDefinition"
+                },
+                "update": {
+                    "$ref": "#/definitions/handlerDefinition"
+                },
+                "delete": {
+                    "$ref": "#/definitions/handlerDefinition"
+                },
+                "list": {
+                    "$ref": "#/definitions/handlerDefinition"
                 }
             },
             "additionalProperties": false

--- a/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 public class ValidatorTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";
-    private static final String EMPTY_SCHEMA_PATH = "/empty-schema.json";
     private static final String TYPE_NAME_KEY = "typeName";
     private static final String PROPERTIES_KEY = "properties";
     private static final String DESCRIPTION_KEY = "description";
@@ -149,5 +148,28 @@ public class ValidatorTest {
                 .isThrownBy(() -> validator.validateResourceDefinition(definition))
                 .withNoCause()
                 .withMessage("#/properties: minimum size: [1], found: [0]");
+    }
+
+    @Test
+    public void validateDefinition_invalidHandlerSection_shouldThrow() {
+
+        final JSONObject definitiion = new JSONObject(
+            new JSONTokener(this.getClass().getResourceAsStream("/invalid-handlers.json"))
+        );
+
+        assertThatExceptionOfType(ValidationException.class)
+            .isThrownBy(() -> validator.validateResourceDefinition(definitiion))
+            .withNoCause()
+            .withMessage("#/handlers/read: #: only 1 subschema matches out of 2");
+    }
+
+    @Test
+    public void validateDefinition_validHandlerSection_shouldNotThrow() {
+
+        final JSONObject definitiion = new JSONObject(
+            new JSONTokener(this.getClass().getResourceAsStream("/valid-with-handlers.json"))
+        );
+
+        validator.validateResourceDefinition(definitiion);
     }
 }

--- a/src/test/resources/invalid-handlers.json
+++ b/src/test/resources/invalid-handlers.json
@@ -1,0 +1,19 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "property1": {
+            "type": "array"
+        }
+    },
+    "handlers": {
+        "create": {
+            "permissions": [
+                "test:permission"
+            ]
+        },
+        "read": {
+            "description": "test"
+        }
+    }
+}

--- a/src/test/resources/valid-with-handlers.json
+++ b/src/test/resources/valid-with-handlers.json
@@ -1,0 +1,36 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "property1": {
+            "type": "array"
+        }
+    },
+    "handlers": {
+        "create": {
+            "permissions": [
+                "test:permission"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "test:permission"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "test:permission"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "test:permission"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "test:permission"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This is a replay of source PR; https://github.com/aws-cloudformation/aws-cloudformation-rpdk/pull/213

Have now uplifted extensible handlers section to the core schema. Additional metadata in the original version is removed as that is better managed on the backend as part of the registration process.

Handler schema added to the resource spec to provide some registration metadata as well as declarative permissions to operate handlers for a particular resource type. Handlers are optional, to allow for schema-only (Data Type) registrations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
