### PR TITLE
Fix schema verification failure

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/ResourceTypeSchema.java
@@ -29,6 +29,7 @@ import org.everit.json.schema.JSONPointer;
 import org.everit.json.schema.ObjectSchema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
 @Getter
 public class ResourceTypeSchema extends ObjectSchema {
@@ -95,8 +96,8 @@ public class ResourceTypeSchema extends ObjectSchema {
 
     public static ResourceTypeSchema load(final JSONObject schemaJson) {
         // first validate incoming resource schema against definition schema
-        Validator.builder().build().validateObject(schemaJson,
-            ResourceTypeSchema.class.getResourceAsStream(SchemaValidator.DEFINITION_SCHEMA_PATH));
+        Validator.builder().build().validateObject(schemaJson, new JSONObject(new JSONTokener(ResourceTypeSchema.class
+            .getResourceAsStream(SchemaValidator.DEFINITION_SCHEMA_PATH))));
 
         // now extract identifiers from resource schema
         final SchemaLoader loader = SchemaLoader.builder().schemaJson(schemaJson)

--- a/src/main/java/com/amazonaws/cloudformation/resource/SchemaValidator.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/SchemaValidator.java
@@ -16,8 +16,6 @@ package com.amazonaws.cloudformation.resource;
 
 import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
 
-import java.io.InputStream;
-
 import org.json.JSONObject;
 
 public interface SchemaValidator {
@@ -29,9 +27,9 @@ public interface SchemaValidator {
      * schema
      *
      * @param modelObject JSON-encoded resource model
-     * @param schemaStream The JSON schema to validate the model against
+     * @param schemaObject The JSON schema object to validate the model against
      * @throws ValidationException Thrown for any schema validation errors
      */
-    void validateObject(JSONObject modelObject, InputStream schemaStream) throws ValidationException;
+    void validateObject(JSONObject modelObject, JSONObject schemaObject) throws ValidationException;
 
 }

--- a/src/main/java/com/amazonaws/cloudformation/resource/Validator.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/Validator.java
@@ -16,7 +16,6 @@ package com.amazonaws.cloudformation.resource;
 
 import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -43,11 +42,6 @@ public class Validator implements SchemaValidator {
     }
 
     @Override
-    public void validateObject(final JSONObject modelObject, final InputStream inputStream) throws ValidationException {
-        final JSONObject schemaObject = new JSONObject(new JSONTokener(inputStream));
-        this.validateObject(modelObject, schemaObject);
-    }
-
     public void validateObject(final JSONObject modelObject, final JSONObject definitionSchemaObject) throws ValidationException {
         try {
             final URI schemaURI = new URI(JSON_SCHEMA_ID);

--- a/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
@@ -48,7 +48,7 @@ public class ValidatorTest {
     public void validateObject_validObject_shouldNotThrow() {
         final JSONObject object = new JSONObject().put("propertyA", "abc").put("propertyB", Arrays.asList(1, 2, 3));
 
-        validator.validateObject(object, this.getClass().getResourceAsStream(TEST_SCHEMA_PATH));
+        validator.validateObject(object, new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH))));
     }
 
     @Test
@@ -56,7 +56,8 @@ public class ValidatorTest {
         final JSONObject object = new JSONObject().put("propertyB", Arrays.asList(1, 2, 3));
 
         final ValidationException e = catchThrowableOfType(
-            () -> validator.validateObject(object, this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)),
+            () -> validator.validateObject(object,
+                new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)))),
             ValidationException.class);
 
         assertThat(e).hasNoCause().hasMessageContaining("propertyA");
@@ -70,7 +71,8 @@ public class ValidatorTest {
             .put("propertyX", "notpartofschema");
 
         final ValidationException e = catchThrowableOfType(
-            () -> validator.validateObject(object, this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)),
+            () -> validator.validateObject(object,
+                new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)))),
             ValidationException.class);
 
         assertThat(e).hasNoCause().hasMessageContaining("propertyX");
@@ -84,7 +86,8 @@ public class ValidatorTest {
             .put("propertyX", "notpartofschema").put("propertyY", "notpartofschema");
 
         final ValidationException e = catchThrowableOfType(
-            () -> validator.validateObject(object, this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)),
+            () -> validator.validateObject(object,
+                new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)))),
             ValidationException.class);
 
         assertThat(e.getCausingExceptions()).hasSize(3);


### PR DESCRIPTION
*Issue #, if available:* #25 

*Description of changes:*
Schema validation will validate user passed in resource schema against provider.definition.schema.v1.json. When loading "provider.definition.schema.v1.json", sometimes it throws "errorMessage":"A JSONObject text must begin with '{' at 0 [character 1 line 1]. 
Changed the way of loading the above json to         definitionSchemaJsonObject = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(METASCHEMA_PATH)));
 inside the constructor to eliminate this failure. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
