### PR TITLE
Apply API validation pattern to sourceUrl, documentationUrl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.5.0-M1</version>
+            <version>5.5.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->

--- a/src/main/java/com/amazonaws/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/ResourceTypeSchema.java
@@ -37,6 +37,7 @@ public class ResourceTypeSchema extends ObjectSchema {
     private final Map<String, Object> unprocessedProperties = new HashMap<>();
 
     private final String sourceUrl;
+    private final String documentationUrl;
     private final String typeName;
     private final List<JSONPointer> createOnlyProperties = new ArrayList<>();
     private final List<JSONPointer> deprecatedProperties = new ArrayList<>();
@@ -54,6 +55,11 @@ public class ResourceTypeSchema extends ObjectSchema {
             ? this.unprocessedProperties.get("sourceUrl").toString()
             : null;
         this.unprocessedProperties.remove("sourceUrl");
+
+        this.documentationUrl = this.unprocessedProperties.containsKey("documentationUrl")
+            ? this.unprocessedProperties.get("documentationUrl").toString()
+            : null;
+        this.unprocessedProperties.remove("documentationUrl");
 
         // typeName is mandatory by schema
         this.typeName = this.unprocessedProperties.get("typeName").toString();

--- a/src/main/resources/examples/resource/initech.tps.report.v1.json
+++ b/src/main/resources/examples/resource/initech.tps.report.v1.json
@@ -2,7 +2,8 @@
     "$id": "initech.tps.report.v1.json",
     "typeName": "Initech::TPS::Report",
     "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-    "sourceUrl": "git@github.com:awslabs/aws-cloudformation-rpdk.git",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
+    "documentationUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk",
     "definitions": {
         "InitechDateFormat": {
             "$comment": "Use the `definitions` block to provide shared resource property schemas",

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -4,6 +4,11 @@
     "title": "CloudFormation Resource Provider Definition MetaSchema",
     "description": "This schema validates a CloudFormation resource provider definition.",
     "definitions": {
+        "httpsUrl": {
+            "type": "string",
+            "pattern": "^https://[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$",
+            "maxLength": 4096
+        },
         "handlerDefinition": {
             "description": "Defines any execution operations which can be performed on this resource provider",
             "type": "object",
@@ -240,14 +245,14 @@
             "examples": [
                 "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-s3"
             ],
-            "type": "string"
+            "$ref": "#/definitions/httpsUrl"
         },
         "documentationUrl": {
             "$comment": "A page with supplemental documentation. The property documentation in schemas should be able to stand alone, but this is an opportunity for e.g. rich examples or more guided documents.",
             "examples": [
                 "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/CHAP_Using.html"
             ],
-            "type": "string"
+            "$ref": "#/definitions/httpsUrl"
         },
         "additionalProperties": {
             "$comment": "All properties of a resource must be expressed in the schema - arbitrary inputs are not allowed",

--- a/src/test/java/com/amazonaws/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -36,7 +36,7 @@ public class ResourceTypeSchemaTest {
         final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
 
         assertThat(schema.getDescription()).isEqualTo("A test schema for unit tests.");
-        assertThat(schema.getSourceUrl()).isEqualTo("my-repo.git");
+        assertThat(schema.getSourceUrl()).isEqualTo("https://mycorp.com/my-repo.git");
         assertThat(schema.getTypeName()).isEqualTo("AWS::Test::TestModel");
         assertThat(schema.getUnprocessedProperties()).isEmpty();
     }
@@ -112,6 +112,7 @@ public class ResourceTypeSchemaTest {
 
         assertThat(schema.getDescription()).isEqualTo("A test schema for unit tests.");
         assertThat(schema.getSourceUrl()).isNull();
+        assertThat(schema.getDocumentationUrl()).isNull();
         assertThat(schema.getTypeName()).isEqualTo("AWS::Test::TestModel");
         assertThat(schema.getUnprocessedProperties()).isEmpty();
         assertThat(schema.getCreateOnlyPropertiesAsStrings()).isEmpty();

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -1,7 +1,7 @@
 {
     "typeName": "AWS::Test::TestModel",
     "description": "A test schema for unit tests.",
-    "sourceUrl": "my-repo.git",
+    "sourceUrl": "https://mycorp.com/my-repo.git",
     "properties": {
         "propertyA": {
             "type": "string"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/270

*Description of changes:* Apply API validation pattern to `sourceUrl`, `documentationUrl`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
