### PR TITLE
Allow permissions of handler to be empty array

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -18,7 +18,6 @@
                     "items": {
                         "type": "string"
                     },
-                    "minItems": 1,
                     "additionalItems": false
                 }
             },

--- a/src/test/resources/valid-with-handlers.json
+++ b/src/test/resources/valid-with-handlers.json
@@ -16,9 +16,7 @@
             ]
         },
         "read": {
-            "permissions": [
-                "test:permission"
-            ]
+            "permissions": []
         },
         "update": {
             "permissions": [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR will allow empty permissions of handler.  In the discussion in PR(https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/pull/161).  In some cases(e.g. external customer doesn't use any AWS resources), handlers don't need any AWS permissions. In such way, we should allow an empty permissions.

Still keep the `permissions` as required so it should explicitly declare all permissions even it's empty. 

 - Make one of handlers permission as empty in the test json to validate this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
