### PR TITLE
Type field which maps to the type in the registry service

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -219,6 +219,11 @@
     },
     "type": "object",
     "properties": {
+        "type": {
+            "$comment": "Resource Type",
+            "type": "string",
+            "const": "RESOURCE"
+        },
         "typeName": {
             "$comment": "Resource Type Identifier",
             "examples": [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add/allow a type field which maps to the type argument for the registry service. Consumers can assume `type` is `RESOURCE` if not specified to remain backwards compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
