### PR TITLE
scrub error messages of any values in schema validation

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/resource/Validator.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/Validator.java
@@ -53,7 +53,7 @@ public class Validator implements SchemaValidator {
             try {
                 schema.validate(modelObject); // throws a ValidationException if this object is invalid
             } catch (final org.everit.json.schema.ValidationException e) {
-                throw new ValidationException(e);
+                throw ValidationException.newScrubbedException(e);
             }
         } catch (final URISyntaxException e) {
             throw new RuntimeException("Invalid URI format for JSON schema.");

--- a/src/test/resources/scrubbed-values-schema.json
+++ b/src/test/resources/scrubbed-values-schema.json
@@ -1,0 +1,94 @@
+{
+  "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
+  "sourceUrl": "my-repo.git",
+  "definitions": {
+    "numberType": {
+      "type": "number",
+      "exclusiveMinimum": 10,
+      "exclusiveMaximum": 20
+    },
+    "integerType": {
+      "type": "integer",
+      "minimum": 10,
+      "maximum": 100,
+      "multipleOf": 5
+    },
+    "arrayType": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 2,
+      "maxItems": 5,
+      "uniqueItems": true
+    },
+    "stringType": {
+      "type": "string",
+      "pattern": "Short",
+      "minLength": 10,
+      "maxLength": 20
+    },
+    "objectType": {
+      "type": "object",
+      "minProperties": 2,
+      "maxProperties": 2
+    }
+  },
+  "properties": {
+    "StringProperty": {
+      "$ref": "#/definitions/stringType"
+    },
+    "StringProperty2": {
+      "$ref": "#/definitions/stringType"
+    },
+    "EnumProperty": {
+      "type": "string",
+      "enum": ["ABC"]
+    },
+    "ConstProperty": {
+      "type": "string",
+      "const": "ABC"
+    },
+    "ArrayProperty": {
+      "$ref": "#/definitions/arrayType"
+    },
+    "ArrayProperty2": {
+      "$ref": "#/definitions/arrayType"
+    },
+    "IntProperty": {
+      "$ref": "#/definitions/integerType"
+    },
+    "IntProperty2": {
+      "$ref": "#/definitions/integerType"
+    },
+    "NumberProperty": {
+      "$ref": "#/definitions/numberType"
+    },
+    "NumberProperty2": {
+      "$ref": "#/definitions/numberType"
+    },
+    "BooleanProperty": {
+      "type": "boolean"
+    },
+    "ObjectProperty": {
+      "$ref": "#/definitions/objectType"
+    },
+    "ObjectProperty2": {
+      "$ref": "#/definitions/objectType"
+    },
+    "MapProperty": {
+      "type": "object",
+      "patternProperties": {
+        "abc": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "primaryIdentifier": [
+    "/properties/StringProperty"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ensure that during schema validation, no messages contain values.

The strategy is to use keywords and change the error message for the ones that emit values.

Certain keywords were whitelisted as safe, in case we start using a new keyword. All other keywords fail with message:
`<SchemaPointer>: failed validation constraint for keyword [<keyword>]`

The following emit values:
* Integer Keywords: `multipleOf`, `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum`
* String Keywords: `pattern`
* `enum`
* `const`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
