### PR TITLE
Prevent atrocious Maven logspam during build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   hooks:
   - id: mvn
     name: Run Java unit tests
-    entry: mvn clean verify
+    entry: mvn clean verify --no-transfer-progress
     language: system
     pass_filenames: false
     always_run: true

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,5 +8,6 @@ phases:
       - pip install pre-commit
   build:
     commands:
-      - pre-commit run --all-files
-      - mvn clean verify --no-transfer-progress
+      - pre-commit run --all-files --verbose
+    finally:
+      - git diff


### PR DESCRIPTION
*Issue #, if available:* #40 

*Description of changes:* Trying to debug CI/build issues was incredibly tedious due to Maven's verbose output. Hopefully this fixes it.

Edit: Turns out `--no-transfer-progress` needs a relatively new Maven, so we need to use the `codebuild:2.0` image, so we also need runtime versions in the `buildspec.yml`. This means this is a breaking PR, i.e. if we merge it, we need to then change the image ASAP, and if we change the image, open PRs need to merge from `master` to pass CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
