### PR TITLE
default value for insertionOrder is true

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -76,7 +76,7 @@
                         "insertionOrder": {
                             "description": "When set to true, this flag indicates that the order of insertion of the array will be honored, and that changing the order of the array would indicate a diff",
                             "type": "boolean",
-                            "default": false
+                            "default": true
                         },
                         "$ref": {
                             "$ref": "https://json-schema.org/draft-07/schema#/properties/$ref"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The default value for insertionOrder should be true, because by default we will honor order (i..e, we assume list by default, rather than set). This kind of makes me think the property should actually be called something else, so that the default value can be false, but I'm not sure we can make that change at this point. If so, would like to have suggestions (my original idea was "orderMatters", which allows us to default to false, but that sounds bad)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
