### PR TITLE
Typo: additionalItems -> additionalProperties

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -21,7 +21,7 @@
                     "additionalItems": false
                 }
             },
-            "additionalItems": false,
+            "additionalProperties": false,
             "required": [
                 "permissions"
             ]

--- a/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
@@ -119,7 +119,7 @@ public class ValidatorTest {
         assertThat(e.getSchemaPointer()).isEqualTo("#/StringProperty");
         assertThat(e.getKeyword()).isEqualTo(keyword);
         assertThat(e.getMessage()).doesNotContain(value);
-        assertThat(e.getCausingExceptions().isEmpty());
+        assertThat(e.getCausingExceptions()).isEmpty();
     }
 
     @ParameterizedTest
@@ -181,7 +181,7 @@ public class ValidatorTest {
         assertThat(e.getKeyword()).isEqualTo(keyword);
         assertThat(e.getSchemaPointer()).isEqualTo("#/" + propName);
         assertThat(e).hasMessageNotContaining(numAsString);
-        assertThat(e.getCausingExceptions().isEmpty());
+        assertThat(e.getCausingExceptions()).isEmpty();
     }
 
     @ParameterizedTest
@@ -203,7 +203,7 @@ public class ValidatorTest {
         assertThat(e.getKeyword()).isEqualTo(keyword);
         assertThat(e.getSchemaPointer()).isEqualTo("#/ObjectProperty");
         assertThat(e).hasMessageNotContaining(val);
-        assertThat(e.getCausingExceptions().isEmpty());
+        assertThat(e.getCausingExceptions()).isEmpty();
     }
 
     @ParameterizedTest
@@ -337,7 +337,7 @@ public class ValidatorTest {
             .getResourceAsStream("/invalid-handlers.json")));
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
-            .withNoCause().withMessage("#/handlers/read: #: only 1 subschema matches out of 2");
+            .withNoCause().withMessage("#/handlers/read: required key [permissions] not found");
     }
 
     @Test

--- a/src/test/resources/invalid-handlers.json
+++ b/src/test/resources/invalid-handlers.json
@@ -15,9 +15,7 @@
                 "test:permission"
             ]
         },
-        "read": {
-            "description": "test"
-        }
+        "read": {}
     },
     "additionalProperties": false
 }


### PR DESCRIPTION
*Issue #, if available:* #39 

*Description of changes:* Typo: additionalItems -> additionalProperties, fixed some asserts that did nothing and this one unit test now that `additionalProperties: false`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
