### PR TITLE
Allow $schema keyword, use canonical draft-07 URI (http)

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -79,46 +79,46 @@
                             "default": true
                         },
                         "$ref": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$ref"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
                         },
                         "$comment": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
                         },
                         "title": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/title"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
                         },
                         "description": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/description"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
                         },
                         "examples": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/examples"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/examples"
                         },
                         "default": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/default"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
                         },
                         "multipleOf": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/multipleOf"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
                         },
                         "maximum": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maximum"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
                         },
                         "exclusiveMaximum": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
                         },
                         "minimum": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minimum"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
                         },
                         "exclusiveMinimum": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
                         },
                         "maxLength": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxLength"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxLength"
                         },
                         "minLength": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minLength"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minLength"
                         },
                         "pattern": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/pattern"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
                         },
                         "items": {
                             "$comment": "Redefined as just a schema. A list of schemas is not allowed",
@@ -126,25 +126,25 @@
                             "default": {}
                         },
                         "maxItems": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxItems"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxItems"
                         },
                         "minItems": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minItems"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minItems"
                         },
                         "uniqueItems": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/uniqueItems"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
                         },
                         "contains": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/contains"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/contains"
                         },
                         "maxProperties": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxProperties"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxProperties"
                         },
                         "minProperties": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minProperties"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minProperties"
                         },
                         "required": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/required"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
                         },
                         "properties": {
                             "type": "object",
@@ -177,22 +177,22 @@
                                         "$ref": "#/definitions/properties"
                                     },
                                     {
-                                        "$ref": "https://json-schema.org/draft-07/schema#/definitions/stringArray"
+                                        "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
                                     }
                                 ]
                             }
                         },
                         "const": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/const"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/const"
                         },
                         "enum": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/enum"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
                         },
                         "type": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/type"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
                         },
                         "format": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/format"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/format"
                         },
                         "allOf": {
                             "$ref": "#/definitions/schemaArray"
@@ -211,6 +211,9 @@
     },
     "type": "object",
     "properties": {
+        "$schema": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/$schema"
+        },
         "type": {
             "$comment": "Resource Type",
             "type": "string",
@@ -227,14 +230,14 @@
             "pattern": "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
         },
         "$comment": {
-            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
         },
         "title": {
-            "$ref": "https://json-schema.org/draft-07/schema#/properties/title"
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
         },
         "description": {
             "$comment": "A short description of the resource provider. This will be shown in the AWS CloudFormation console.",
-            "$ref": "https://json-schema.org/draft-07/schema#/properties/description"
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
         },
         "sourceUrl": {
             "$comment": "The location of the source code for this resource provider, to help interested parties submit issues or improvements.",
@@ -305,7 +308,7 @@
                     "type": "object",
                     "properties": {
                         "$comment": {
-                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
+                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
                         },
                         "properties": {
                             "$ref": "#/properties/properties"
@@ -348,7 +351,7 @@
             }
         },
         "required": {
-            "$ref": "https://json-schema.org/draft-07/schema#/properties/required"
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
         },
         "allOf": {
             "$ref": "#/definitions/schemaArray"

--- a/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
@@ -384,4 +384,11 @@ public class ValidatorTest {
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
             .withMessageContaining("#/sourceUrl").withMessageContaining(Integer.toString(sourceUrl.length()));
     }
+
+    @Test
+    public void validateDefinition_schemaKeyword_shouldBeAllowed() {
+        final JSONObject definition = baseSchema().put("$schema", "http://json-schema.org/draft-07/schema#");
+
+        validator.validateResourceDefinition(definition);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Depends on #50 to be merged first. The draft-07 URI is `http://json-schema.org/draft-07/schema`, even when loaded over HTTPS, so we should use that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
