### PR TITLE
Refactored namespace from redundant AWS groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.amazonaws.cloudformation</groupId>
+    <groupId>software.amazon.cloudformation</groupId>
     <artifactId>aws-cloudformation-resource-schema</artifactId>
     <version>1.0.3</version>
     <properties>

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -12,9 +12,7 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource;
-
-import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
+package software.amazon.cloudformation.resource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +28,8 @@ import org.everit.json.schema.ObjectSchema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+
+import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 @Getter
 public class ResourceTypeSchema extends ObjectSchema {

--- a/src/main/java/software/amazon/cloudformation/resource/SchemaValidator.java
+++ b/src/main/java/software/amazon/cloudformation/resource/SchemaValidator.java
@@ -12,11 +12,11 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource;
-
-import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
+package software.amazon.cloudformation.resource;
 
 import org.json.JSONObject;
+
+import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 public interface SchemaValidator {
 

--- a/src/main/java/software/amazon/cloudformation/resource/Validator.java
+++ b/src/main/java/software/amazon/cloudformation/resource/Validator.java
@@ -12,9 +12,7 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource;
-
-import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
+package software.amazon.cloudformation.resource;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -25,6 +23,8 @@ import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+
+import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 public class Validator implements SchemaValidator {
 

--- a/src/main/java/software/amazon/cloudformation/resource/exceptions/ValidationException.java
+++ b/src/main/java/software/amazon/cloudformation/resource/exceptions/ValidationException.java
@@ -12,7 +12,7 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource.exceptions;
+package software.amazon.cloudformation.resource.exceptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -12,18 +12,18 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource;
+package software.amazon.cloudformation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
-import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
 
 import java.util.List;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.Test;
+
+import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 public class ResourceTypeSchemaTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -12,13 +12,11 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource;
+package software.amazon.cloudformation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
-
-import com.amazonaws.cloudformation.resource.exceptions.ValidationException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 public class ValidatorTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";

--- a/src/test/java/software/amazon/cloudformation/resource/exceptions/ValidationExceptionTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/exceptions/ValidationExceptionTest.java
@@ -12,7 +12,7 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package com.amazonaws.cloudformation.resource.exceptions;
+package software.amazon.cloudformation.resource.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* In order to publish to Maven we need to update our namespace to AWS' newer Sontatype groupId


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
