### PR TITLE
Set default taggable to false when UpdateHandler not provided

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -92,11 +92,6 @@ public class ResourceTypeSchema {
             : "create_then_delete";
         this.unprocessedProperties.remove("replacementStrategy");
 
-        this.taggable = this.unprocessedProperties.containsKey("taggable")
-            ? Boolean.valueOf(this.unprocessedProperties.get("taggable").toString())
-            : true;
-        this.unprocessedProperties.remove("taggable");
-
         this.unprocessedProperties.computeIfPresent("conditionalCreateOnlyProperties", (k, v) -> {
             ((ArrayList<?>) v).forEach(p -> this.conditionalCreateOnlyProperties.add(new JSONPointer(p.toString())));
             return null;
@@ -153,6 +148,11 @@ public class ResourceTypeSchema {
             });
             return null;
         });
+
+        this.taggable = this.unprocessedProperties.containsKey("taggable")
+            ? Boolean.valueOf(this.unprocessedProperties.get("taggable").toString())
+            : this.handlers.containsKey("update");
+        this.unprocessedProperties.remove("taggable");
     }
 
     public static ResourceTypeSchema load(final JSONObject resourceDefinition) {

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -304,7 +304,7 @@
         "taggable": {
             "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
             "type": "boolean",
-            "default": true
+            "default": "Default to true if there's an UpdateHandler, and false if no UpdateHandler is provided."
         },
         "replacementStrategy": {
             "$comment": "The order of replacement for an immutable resource update.",

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -304,7 +304,7 @@
         "taggable": {
             "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
             "type": "boolean",
-            "default": "Default to true if there's an UpdateHandler, and false if no UpdateHandler is provided."
+            "description": "Default to true if there's an UpdateHandler, and false if no UpdateHandler is provided."
         },
         "replacementStrategy": {
             "$comment": "The order of replacement for an immutable resource update.",

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -38,6 +38,7 @@ public class ResourceTypeSchemaTest {
     private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
     private static final String WRITEONLY_MODEL_PATH = "/write-only-model.json";
     private static final String HANDLERS_SCHEMA_PATH = "/valid-with-handlers-schema.json";
+    private static final String SCHEMA_WIRH_UPDATE_HANDLER_PATH = "/valid-with-update-handler-schema.json";
 
     @Test
     public void getProperties() {
@@ -142,7 +143,22 @@ public class ResourceTypeSchemaTest {
 
         String replacementStrategy = schema.getReplacementStrategy();
         assertThat(replacementStrategy).isEqualTo("delete_then_create");
+    }
+
+    @Test
+    public void schemaWithUpdateHandlerShouldBeTaggable() {
+        JSONObject o = loadJSON(SCHEMA_WIRH_UPDATE_HANDLER_PATH);
+        final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+
         assertThat(schema.isTaggable()).isTrue();
+    }
+
+    @Test
+    public void schemaWithoutUpdateHandlerShouldNotBeTaggable() {
+        JSONObject o = loadJSON(HANDLERS_SCHEMA_PATH);
+        final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+
+        assertThat(schema.isTaggable()).isFalse();
     }
 
     @Test

--- a/src/test/resources/valid-with-update-handler-schema.json
+++ b/src/test/resources/valid-with-update-handler-schema.json
@@ -1,0 +1,37 @@
+{
+  "typeName": "AWS::Valid::TypeName",
+  "description": "A test schema for unit tests.",
+  "properties": {
+    "property1": {
+      "type": "array"
+    }
+  },
+  "primaryIdentifier": [
+    "/property1"
+  ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "test:permission"
+      ],
+      "timeoutInMinutes": 200
+    },
+    "update": {
+      "permissions": []
+    },
+    "read": {
+      "permissions": []
+    },
+    "delete": {
+      "permissions": [
+        "test:permissionA"
+      ]
+    },
+    "list": {
+      "permissions": [
+        "test:permissionB"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/valid-with-update-handler-schema.json
+++ b/src/test/resources/valid-with-update-handler-schema.json
@@ -1,37 +1,37 @@
 {
-  "typeName": "AWS::Valid::TypeName",
-  "description": "A test schema for unit tests.",
-  "properties": {
-    "property1": {
-      "type": "array"
-    }
-  },
-  "primaryIdentifier": [
-    "/property1"
-  ],
-  "handlers": {
-    "create": {
-      "permissions": [
-        "test:permission"
-      ],
-      "timeoutInMinutes": 200
+    "typeName": "AWS::Valid::TypeName",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "property1": {
+            "type": "array"
+        }
     },
-    "update": {
-      "permissions": []
+    "primaryIdentifier": [
+        "/property1"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "test:permission"
+            ],
+            "timeoutInMinutes": 200
+        },
+        "update": {
+            "permissions": []
+        },
+        "read": {
+            "permissions": []
+        },
+        "delete": {
+            "permissions": [
+                "test:permissionA"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "test:permissionB"
+            ]
+        }
     },
-    "read": {
-      "permissions": []
-    },
-    "delete": {
-      "permissions": [
-        "test:permissionA"
-      ]
-    },
-    "list": {
-      "permissions": [
-        "test:permissionB"
-      ]
-    }
-  },
-  "additionalProperties": false
+    "additionalProperties": false
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-resource-schema/pull/105#discussion_r634834873
*Description of changes:*
As discussed with @PatMyron offline, we need to set the default value of taggable to be false when UpdateHandler is not provided, so that update on stack level tags won't trigger the replace update of the resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
