### PR TITLE
Add nonPublicProperties and nonPublicDefinitions lists of JSONPointers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -204,6 +204,14 @@
             "description": "A list of JSON pointers for properties that can only be updated under certain conditions. For example, you can upgrade the engine version of an RDS DBInstance but you cannot downgrade it.  When updating this property for a resource in a CloudFormation stack, the resource will be replaced if it cannot be updated.",
             "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
         },
+        "nonPublicProperties": {
+            "description": "A list of JSON pointers for properties that are hidden. These properties will still be used but will not be visible",
+            "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
+        },
+        "nonPublicDefinitions": {
+            "description": "A list of JSON pointers for definitions that are hidden. These definitions will still be used but will not be visible",
+            "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
+        },
         "createOnlyProperties": {
             "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -44,6 +44,8 @@ public class ResourceTypeSchemaTest {
     private static final String MINIMAL_SCHEMA_WITH_INVALID_TYPE_CONFIGURATION_PATH = "/minimal-schema-with-invalid-typeconfiguration.json";
     private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
     private static final String HANDLERS_SCHEMA_PATH = "/valid-with-handlers-schema.json";
+    private static final String SCHEMA_WITH_HIDDEN_PATHS = "/test-schema-with-hidden-pointers.json";
+    private static final String SCHEMA_WITH_HIDDEN_PATHS_INVALID = "/test-schema-with-invalid-hidden-pointers.json";
 
     @Test
     public void getProperties() {
@@ -366,6 +368,26 @@ public class ResourceTypeSchemaTest {
 
         assertThat(schema.hasHandler("list")).isTrue();
         assertThat(schema.getHandlerPermissions("list")).contains("test:permissionB");
+    }
+
+    /**
+     * Test loading the nonPublicProperties and nonPublicDefinitions
+     */
+    @Test
+    public void test_loadSchemaWithHiddenPaths() {
+        JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_HIDDEN_PATHS);
+        ResourceTypeSchema.load(resourceDefinition);
+    }
+
+    /**
+     * Test loading an invalid schema with hidden paths in incorrect section
+     */
+    @Test
+    public void test_loadSchemaWithHiddenPaths_withInvalidHiddenPaths() {
+        JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_HIDDEN_PATHS_INVALID);
+        assertThatExceptionOfType(ValidationException.class)
+            .isThrownBy(() -> ResourceTypeSchema.load(resourceDefinition))
+            .withMessageContaining("2 schema violations found"); // nonPublicProperties and definitions in properties section
     }
 
     /**

--- a/src/test/resources/test-schema-with-hidden-pointers.json
+++ b/src/test/resources/test-schema-with-hidden-pointers.json
@@ -1,0 +1,45 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema with hidden paths for unit tests",
+    "sourceUrl": "https://mycorp.com/my-repo.git",
+    "definitions": {
+        "definition1": {
+            "type": "string"
+        }
+    },
+    "properties": {
+        "propertyA": {
+            "type": "string"
+        },
+        "propertyB": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        },
+        "propertyC": {
+            "type": "object",
+            "properties": {
+                "nestedProperty": {
+                    "type": "string"
+                },
+                "writeOnlyArray": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "nonPublicProperties": [
+        "/properties/propertyC/properties/nestedProperty",
+        "/properties/propertyA"
+    ],
+    "nonPublicDefinitions": [
+        "/definitions/definition1"
+    ],
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "create_then_delete",
+    "taggable": false,
+    "additionalProperties": false
+}

--- a/src/test/resources/test-schema-with-invalid-hidden-pointers.json
+++ b/src/test/resources/test-schema-with-invalid-hidden-pointers.json
@@ -1,0 +1,52 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema with hidden paths for unit tests",
+    "sourceUrl": "https://mycorp.com/my-repo.git",
+    "definitions": {
+        "definition1": {
+            "type": "string"
+        }
+    },
+    "properties": {
+        "nonPublicProperties": [
+            "/properties/propertyC/properties/nestedProperty",
+            "/properties/propertyA"
+        ],
+        "nonPublicDefinitions": [
+            "/definitions/definition1"
+        ],
+        "propertyA": {
+            "type": "string"
+        },
+        "propertyB": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        },
+        "propertyC": {
+            "type": "object",
+            "properties": {
+                "nestedProperty": {
+                    "type": "string"
+                },
+                "writeOnlyArray": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "nonPublicProperties": [
+        "/properties/propertyC/properties/nestedProperty",
+        "/properties/propertyA"
+    ],
+    "nonPublicDefinitions": [
+        "/definitions/definition1"
+    ],
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "create_then_delete",
+    "taggable": false,
+    "additionalProperties": false
+}


### PR DESCRIPTION
*Description of changes:*

Add nonPublicProperties and nonPublicDefinitions lists of JSONPointers in metaschema. Adding top level lists to allow hidden
property and definition paths to be accepted. Also update lombok version as it fails local build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
