### PR TITLE
fix a NPE with nested writeOnlyProperties with optional parent.

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -266,8 +267,9 @@ public class ResourceTypeSchema {
                 if (refTokens.size() > 1) {
                     // use sublist to specify to point at the parent object
                     final JSONPointer parentObjectPointer = new JSONPointer(refTokens.subList(0, refTokens.size() - 1));
-                    final JSONObject parentObject = (JSONObject) parentObjectPointer.queryFrom(resourceModel);
-                    parentObject.remove(key);
+                    final Optional<JSONObject> parentObject = Optional.ofNullable(
+                        (JSONObject) parentObjectPointer.queryFrom(resourceModel));
+                    parentObject.ifPresent(jsonObject -> jsonObject.remove(key));
                 } else {
                     resourceModel.remove(key);
                 }

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -217,6 +217,27 @@ public class ResourceTypeSchemaTest {
     }
 
     @Test
+    public void removeWriteOnlyProperties_hasNestedWriteOnlyPropertyWithNullParent_shouldRemove() {
+        JSONObject o = loadJSON(TEST_SCHEMA_PATH);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+        JSONObject resourceModel = o.getJSONObject("properties");
+
+        // remove parent element which contains writeOnlyProperty "/properties/propertyE/nestedProperty"
+        resourceModel.remove("propertyE");
+
+        schema.removeWriteOnlyProperties(resourceModel);
+
+        // check that model doesn't contain the writeOnly properties
+
+        assertThat(schema.getWriteOnlyPropertiesAsStrings().stream()
+            .anyMatch(writeOnlyProperty -> new PublicJSONPointer(writeOnlyProperty.replaceFirst("^/properties", ""))
+                .isInObject(resourceModel))).isFalse();
+
+        // ensure that other non writeOnlyProperty is not removed
+        assertThat(resourceModel.has("propertyB")).isTrue();
+    }
+
+    @Test
     public void removeWriteOnlyProperties_hasWriteOnlyProperties_shouldDoNothing() {
         JSONObject o = loadJSON(TEST_SCHEMA_WITH_EMPTY_WRITE_ONLY_PATH);
         ResourceTypeSchema schema = ResourceTypeSchema.load(o);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the removeProperty function to catch NullPointerException, as this implies the parent object was null when removing a nested property. This function is intended to take no action when the property to be removed was null, so it should take no action in this case as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
