### PR TITLE
Add custom tag arrayType

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Together with the `uniqueItems` property (which is native to JSON Schema), compl
 
 #### arrayType
 
-`arrayType` is used to specify the type of array and is only applicable for properties of type array. When  set to `AttributeList`, it indicates that the array is of nested type objects, and when set to `Standard` it indicates that the array consists of primitive types. The default for `arrayType` is `Standard`.
+`arrayType` is used to specify the type of array and is only applicable for properties of type array. When set to `AttributeList`, it indicates that the array is used to represent a list of additional properties, and when set to `Standard` it indicates that the array consists of a list of values. The default for `arrayType` is `Standard`. 
+For example, 'Standard' would be used for an array of Arn values, where the addition of the values themselves has significance. 
+An example of using 'AttributeList' would be for a list of optional, and often defaulted, values that can be specified. For example, 'AttributeList' would be used for an array of TargetGroupAttributes for ELB where addition of the default values has no significance.
 
 ### Constraints
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Together with the `uniqueItems` property (which is native to JSON Schema), compl
 | true           | true           | ordered set    |
 | false          | true           | set      |
 
+#### arrayType
+
+`arrayType` is used to specify the type of array and is only applicable for properties of type array. When  set to `AttributeList`, it indicates that the array is of nested type objects, and when set to `Standard` it indicates that the array consists of primitive types. The default for `arrayType` is `Standard`.
 
 ### Constraints
 

--- a/src/main/resources/schema/base.definition.schema.v1.json
+++ b/src/main/resources/schema/base.definition.schema.v1.json
@@ -61,6 +61,15 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "arrayType": {
+                            "description": "When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types",
+                            "type": "string",
+                            "default": "Standard",
+                            "enum": [
+                                "Standard",
+                                "AttributeList"
+                            ]
+                        },
                         "$ref": {
                             "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
                         },

--- a/src/test/resources/invalid-update-tagging-schema.json
+++ b/src/test/resources/invalid-update-tagging-schema.json
@@ -9,6 +9,7 @@
             "description": "A list of tags to apply to the resource.",
             "type": "array",
             "uniqueItems": true,
+            "arrayType": "Standard",
             "insertionOrder": false
         }
     },

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -8,6 +8,7 @@
         },
         "propertyB": {
             "type": "array",
+            "arrayType": "AttributeList",
             "items": {
                 "type": "integer"
             }

--- a/src/test/resources/valid-with-tagging-schema.json
+++ b/src/test/resources/valid-with-tagging-schema.json
@@ -9,6 +9,7 @@
             "description": "A list of tags to apply to the resource.",
             "type": "array",
             "uniqueItems": true,
+            "arrayType": "Standard",
             "insertionOrder": false
         }
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
arrayType is only applicable for property of type array. When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
