### PR TITLE
Bump everit-json-schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Together with the `uniqueItems` property (which is native to JSON Schema), compl
 
 #### arrayType
 
-`arrayType` is used to specify the type of array and is only applicable for properties of type array. When set to `AttributeList`, it indicates that the array is used to represent a list of additional properties, and when set to `Standard` it indicates that the array consists of a list of values. The default for `arrayType` is `Standard`. 
-For example, 'Standard' would be used for an array of Arn values, where the addition of the values themselves has significance. 
+`arrayType` is used to specify the type of array and is only applicable for properties of type array. When set to `AttributeList`, it indicates that the array is used to represent a list of additional properties, and when set to `Standard` it indicates that the array consists of a list of values. The default for `arrayType` is `Standard`.
+For example, 'Standard' would be used for an array of Arn values, where the addition of the values themselves has significance.
 An example of using 'AttributeList' would be for a list of optional, and often defaulted, values that can be specified. For example, 'AttributeList' would be used for an array of TargetGroupAttributes for ELB where addition of the default values has no significance.
 
 ### Constraints

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,11 @@
         <url>https://github.com/aws-cloudformation/aws-cloudformation-resource-schema</url>
     </scm>
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/com.github.everit-org.json-schema/org.everit.json.schema -->
+        <!-- https://mvnrepository.com/artifact/com.github.erosb/everit-json-schema -->
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
-            <version>1.11.0</version>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
+            <version>1.14.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
@@ -91,13 +91,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <!-- Supports org.everit.json.schema per https://github.com/everit-org/json-schema -->
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
This version is also available through maven central. The group id changed but that is the one to use according to the homepage https://github.com/everit-org/json-schema

*Issue #, if available:* not available

*Description of changes:*
Just bumped one of the dependencies. The main benefit is that now all dependencies are available on maven central.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
