### PR TITLE
Add permissions to tagging schema

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
@@ -14,8 +14,8 @@
 */
 package software.amazon.cloudformation.resource;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -41,7 +41,7 @@ public class ResourceTagging {
     private boolean tagUpdatable;
     private boolean cloudFormationSystemTags;
     private JSONPointer tagProperty;
-    private Set<String> tagPermissions;
+    private List<String> tagPermissions;
 
     public ResourceTagging(final boolean taggableValue) {
         this.taggable = taggableValue;
@@ -49,7 +49,7 @@ public class ResourceTagging {
         this.tagUpdatable = taggableValue;
         this.cloudFormationSystemTags = taggableValue;
         this.tagProperty = new JSONPointer("/properties/Tags");
-        this.tagPermissions = new HashSet<>();
+        this.tagPermissions = new ArrayList<>();
     }
 
     public void resetTaggable(final boolean taggableValue) {

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
@@ -14,6 +14,9 @@
 */
 package software.amazon.cloudformation.resource;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -30,6 +33,7 @@ public class ResourceTagging {
     public static final String TAG_UPDATABLE = "tagUpdatable";
     public static final String CLOUDFORMATION_SYSTEM_TAGS = "cloudFormationSystemTags";
     public static final String TAG_PROPERTY = "tagProperty";
+    public static final String TAG_PERMISSIONS = "permissions";
     public static final ResourceTagging DEFAULT = new ResourceTagging(true);
 
     private boolean taggable;
@@ -37,6 +41,7 @@ public class ResourceTagging {
     private boolean tagUpdatable;
     private boolean cloudFormationSystemTags;
     private JSONPointer tagProperty;
+    private Set<String> tagPermissions;
 
     public ResourceTagging(final boolean taggableValue) {
         this.taggable = taggableValue;
@@ -44,6 +49,7 @@ public class ResourceTagging {
         this.tagUpdatable = taggableValue;
         this.cloudFormationSystemTags = taggableValue;
         this.tagProperty = new JSONPointer("/properties/Tags");
+        this.tagPermissions = new HashSet<>();
     }
 
     public void resetTaggable(final boolean taggableValue) {

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -167,7 +167,7 @@ public class ResourceTypeSchema {
                 } else if (key.equals(ResourceTagging.TAG_PROPERTY)) {
                     taggingValue.setTagProperty(new JSONPointer(value.toString()));
                 } else if (key.equals(ResourceTagging.TAG_PERMISSIONS)) {
-                    HashSet<String> tagPermissions = new HashSet<>();
+                    List<String> tagPermissions = new ArrayList<>();
                     ((List<?>) value).forEach(p -> tagPermissions.add(p.toString()));
                     taggingValue.setTagPermissions(tagPermissions);
                 } else {

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -166,6 +166,10 @@ public class ResourceTypeSchema {
                     taggingValue.setCloudFormationSystemTags(Boolean.parseBoolean(value.toString()));
                 } else if (key.equals(ResourceTagging.TAG_PROPERTY)) {
                     taggingValue.setTagProperty(new JSONPointer(value.toString()));
+                } else if (key.equals(ResourceTagging.TAG_PERMISSIONS)) {
+                    HashSet<String> tagPermissions = new HashSet<>();
+                    ((List<?>) value).forEach(p -> tagPermissions.add(p.toString()));
+                    taggingValue.setTagPermissions(tagPermissions);
                 } else {
                     throw new ValidationException("Unexpected tagging metadata attribute", "tagging", "#/tagging/" + key);
                 }

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -145,6 +145,13 @@
                     "description": "A reference to the Tags property in the schema.",
                     "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref",
                     "default": "/properties/Tags"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "additionalItems": false
                 }
             },
             "required": [

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTaggingTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTaggingTest.java
@@ -16,6 +16,8 @@ package software.amazon.cloudformation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashSet;
+
 import org.everit.json.schema.JSONPointer;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +26,7 @@ public class ResourceTaggingTest {
     public void testResetTaggable() {
 
         final ResourceTagging resourceTagging = new ResourceTagging(true, true, true,
-                                                                    true, new JSONPointer("/properties/tags"));
+                                                                    true, new JSONPointer("/properties/tags"), new HashSet<>());
         resourceTagging.resetTaggable(false);
 
         assertThat(resourceTagging.isTaggable()).isEqualTo(false);
@@ -32,5 +34,6 @@ public class ResourceTaggingTest {
         assertThat(resourceTagging.isTagUpdatable()).isEqualTo(false);
         assertThat(resourceTagging.isCloudFormationSystemTags()).isEqualTo(false);
         assertThat(resourceTagging.getTagProperty().toString()).isEqualTo("/properties/tags");
+        assertThat(resourceTagging.getTagPermissions().isEmpty());
     }
 }

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTaggingTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTaggingTest.java
@@ -16,7 +16,7 @@ package software.amazon.cloudformation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 
 import org.everit.json.schema.JSONPointer;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ public class ResourceTaggingTest {
     public void testResetTaggable() {
 
         final ResourceTagging resourceTagging = new ResourceTagging(true, true, true,
-                                                                    true, new JSONPointer("/properties/tags"), new HashSet<>());
+                                                                    true, new JSONPointer("/properties/tags"), new ArrayList<>());
         resourceTagging.resetTaggable(false);
 
         assertThat(resourceTagging.isTaggable()).isEqualTo(false);

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -427,6 +427,7 @@ public class ResourceTypeSchemaTest {
         assertThat(schema.getTagging().isCloudFormationSystemTags()).isEqualTo(false);
         assertThat(schema.definesProperty("propertyB")).isTrue();
         assertThat(schema.getTagging().getTagProperty()).asString().isEqualTo("/properties/propertyB");
+        assertThat(schema.getTagging().getTagPermissions()).contains("test:permission");
     }
 
     /**

--- a/src/test/resources/valid-with-tagging-schema.json
+++ b/src/test/resources/valid-with-tagging-schema.json
@@ -22,7 +22,10 @@
         "tagOnCreate": true,
         "tagUpdatable": false,
         "cloudFormationSystemTags": false,
-        "tagProperty": "/properties/propertyB"
+        "tagProperty": "/properties/propertyB",
+        "permissions": [
+            "test:permission"
+        ]
     },
     "additionalProperties": false
 }


### PR DESCRIPTION
Add permissions field in tagging schema to specify permissions needed for tags.

Add unit test for permissions field.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
