### PR TITLE
Allowed Nested reference for TagProperty

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTagging.java
@@ -64,7 +64,15 @@ public class ResourceTagging {
             throw new ValidationException("Invalid tagUpdatable value since update handler is missing", "tagging",
                                           "#/tagging/tagUpdatable");
         }
-        final String propertyName = this.tagProperty.toString().substring(this.tagProperty.toString().lastIndexOf('/') + 1);
+
+        final String propertiesPrefix = "/properties/";
+        if (!this.tagProperty.toString().startsWith(propertiesPrefix)) {
+            final String errorMessage = String.format("Invalid tagProperty value %s must start with \"/properties\"",
+                this.tagProperty.toString());
+            throw new ValidationException(errorMessage, "tagging", "#/tagging/tagProperty");
+        }
+
+        final String propertyName = this.tagProperty.toString().substring(propertiesPrefix.length());
         if (this.taggable && !schema.definesProperty(propertyName)) {
             final String errorMessage = String.format("Invalid tagProperty value since %s not found in schema", propertyName);
             throw new ValidationException(errorMessage, "tagging", "#/tagging/tagProperty");

--- a/src/test/resources/invalid-with-tagging-bad-pointer-schema.json
+++ b/src/test/resources/invalid-with-tagging-bad-pointer-schema.json
@@ -1,31 +1,31 @@
 {
-  "typeName": "AWS::Test::TestModel",
-  "description": "A test schema for unit tests.",
-  "properties": {
-    "propertyA": {
-      "type": "boolean"
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "propertyA": {
+            "type": "boolean"
+        },
+        "propertyB": {
+            "description": "A list of tags to apply to the resource.",
+            "type": "array",
+            "uniqueItems": true,
+            "arrayType": "Standard",
+            "insertionOrder": false
+        }
     },
-    "propertyB": {
-      "description": "A list of tags to apply to the resource.",
-      "type": "array",
-      "uniqueItems": true,
-      "arrayType": "Standard",
-      "insertionOrder": false
-    }
-  },
-  "primaryIdentifier": [
-    "/properties/propertyA"
-  ],
-  "replacementStrategy": "delete_then_create",
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": false,
-    "tagProperty": "propertyB",
-    "permissions": [
-      "test:permission"
-    ]
-  },
-  "additionalProperties": false
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "delete_then_create",
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": false,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "propertyB",
+        "permissions": [
+            "test:permission"
+        ]
+    },
+    "additionalProperties": false
 }

--- a/src/test/resources/invalid-with-tagging-bad-pointer-schema.json
+++ b/src/test/resources/invalid-with-tagging-bad-pointer-schema.json
@@ -1,0 +1,31 @@
+{
+  "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
+  "properties": {
+    "propertyA": {
+      "type": "boolean"
+    },
+    "propertyB": {
+      "description": "A list of tags to apply to the resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "arrayType": "Standard",
+      "insertionOrder": false
+    }
+  },
+  "primaryIdentifier": [
+    "/properties/propertyA"
+  ],
+  "replacementStrategy": "delete_then_create",
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "propertyB",
+    "permissions": [
+      "test:permission"
+    ]
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/invalid-with-tagging-bad-reference-schema.json
+++ b/src/test/resources/invalid-with-tagging-bad-reference-schema.json
@@ -1,0 +1,31 @@
+{
+  "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
+  "properties": {
+    "propertyA": {
+      "type": "boolean"
+    },
+    "propertyB": {
+      "description": "A list of tags to apply to the resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "arrayType": "Standard",
+      "insertionOrder": false
+    }
+  },
+  "primaryIdentifier": [
+    "/properties/propertyA"
+  ],
+  "replacementStrategy": "delete_then_create",
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "/propertyB",
+    "permissions": [
+      "test:permission"
+    ]
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/invalid-with-tagging-bad-reference-schema.json
+++ b/src/test/resources/invalid-with-tagging-bad-reference-schema.json
@@ -1,31 +1,31 @@
 {
-  "typeName": "AWS::Test::TestModel",
-  "description": "A test schema for unit tests.",
-  "properties": {
-    "propertyA": {
-      "type": "boolean"
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "propertyA": {
+            "type": "boolean"
+        },
+        "propertyB": {
+            "description": "A list of tags to apply to the resource.",
+            "type": "array",
+            "uniqueItems": true,
+            "arrayType": "Standard",
+            "insertionOrder": false
+        }
     },
-    "propertyB": {
-      "description": "A list of tags to apply to the resource.",
-      "type": "array",
-      "uniqueItems": true,
-      "arrayType": "Standard",
-      "insertionOrder": false
-    }
-  },
-  "primaryIdentifier": [
-    "/properties/propertyA"
-  ],
-  "replacementStrategy": "delete_then_create",
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": false,
-    "tagProperty": "/propertyB",
-    "permissions": [
-      "test:permission"
-    ]
-  },
-  "additionalProperties": false
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "delete_then_create",
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": false,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/propertyB",
+        "permissions": [
+            "test:permission"
+        ]
+    },
+    "additionalProperties": false
 }

--- a/src/test/resources/valid-with-tagging-missing-tagProperty-schema.json
+++ b/src/test/resources/valid-with-tagging-missing-tagProperty-schema.json
@@ -1,46 +1,46 @@
 {
-  "typeName": "AWS::Test::TestModel",
-  "description": "A test schema for unit tests.",
-  "definitions": {
-    "Tag": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "Key": {
-          "description": "The key name of the tag",
-          "type": "string"
-        },
-        "Value": {
-          "description": "The value for the tag",
-          "type": "string"
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "definitions": {
+        "Tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "description": "The key name of the tag",
+                    "type": "string"
+                },
+                "Value": {
+                    "description": "The value for the tag",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
         }
-      },
-      "required": [
-        "Value",
-        "Key"
-      ]
-    }
-  },
-  "properties": {
-    "propertyA": {
-      "type": "boolean"
     },
-    "Tags": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    }
-  },
-  "primaryIdentifier": [
-    "/properties/propertyA"
-  ],
-  "replacementStrategy": "delete_then_create",
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": false
-  },
-  "additionalProperties": false
+    "properties": {
+        "propertyA": {
+            "type": "boolean"
+        },
+        "Tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Tag"
+            }
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "delete_then_create",
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": false,
+        "cloudFormationSystemTags": false
+    },
+    "additionalProperties": false
 }

--- a/src/test/resources/valid-with-tagging-missing-tagProperty-schema.json
+++ b/src/test/resources/valid-with-tagging-missing-tagProperty-schema.json
@@ -1,0 +1,46 @@
+{
+  "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
+  "definitions": {
+    "Tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "description": "The key name of the tag",
+          "type": "string"
+        },
+        "Value": {
+          "description": "The value for the tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Value",
+        "Key"
+      ]
+    }
+  },
+  "properties": {
+    "propertyA": {
+      "type": "boolean"
+    },
+    "Tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    }
+  },
+  "primaryIdentifier": [
+    "/properties/propertyA"
+  ],
+  "replacementStrategy": "delete_then_create",
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/valid-with-tagging-nested-property-schema.json
+++ b/src/test/resources/valid-with-tagging-nested-property-schema.json
@@ -1,61 +1,61 @@
 {
-  "typeName": "AWS::Test::TestModel",
-  "description": "A test schema for unit tests.",
-  "definitions": {
-    "propertyC": {
-      "type": "object",
-      "properties":{
-        "Tags": {
-          "description": "An array of arbitrary tags (key-value pairs) to associate with the stage.",
-          "type": "array",
-          "uniqueItems": false,
-          "insertionOrder": false,
-          "items": {
-            "$ref": "#/definitions/Tag"
-          }
-        }
-      }
-    },
-    "Tag": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "Key": {
-          "description": "The key name of the tag",
-          "type": "string"
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "definitions": {
+        "propertyC": {
+            "type": "object",
+            "properties": {
+                "Tags": {
+                    "description": "An array of arbitrary tags (key-value pairs) to associate with the stage.",
+                    "type": "array",
+                    "uniqueItems": false,
+                    "insertionOrder": false,
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                }
+            }
         },
-        "Value": {
-          "description": "The value for the tag",
-          "type": "string"
+        "Tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "description": "The key name of the tag",
+                    "type": "string"
+                },
+                "Value": {
+                    "description": "The value for the tag",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
         }
-      },
-      "required": [
-        "Value",
-        "Key"
-      ]
-    }
-  },
-  "properties": {
-    "propertyA": {
-      "type": "boolean"
     },
-    "propertyC": {
-      "$ref": "#/definitions/propertyC"
-    }
-  },
-  "primaryIdentifier": [
-    "/properties/propertyA"
-  ],
-  "replacementStrategy": "delete_then_create",
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": false,
-    "tagProperty": "/properties/propertyC/Tags",
-    "permissions": [
-      "test:permission"
-    ]
-  },
-  "additionalProperties": false
+    "properties": {
+        "propertyA": {
+            "type": "boolean"
+        },
+        "propertyC": {
+            "$ref": "#/definitions/propertyC"
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/propertyA"
+    ],
+    "replacementStrategy": "delete_then_create",
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": false,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/properties/propertyC/Tags",
+        "permissions": [
+            "test:permission"
+        ]
+    },
+    "additionalProperties": false
 }

--- a/src/test/resources/valid-with-tagging-nested-property-schema.json
+++ b/src/test/resources/valid-with-tagging-nested-property-schema.json
@@ -1,0 +1,61 @@
+{
+  "typeName": "AWS::Test::TestModel",
+  "description": "A test schema for unit tests.",
+  "definitions": {
+    "propertyC": {
+      "type": "object",
+      "properties":{
+        "Tags": {
+          "description": "An array of arbitrary tags (key-value pairs) to associate with the stage.",
+          "type": "array",
+          "uniqueItems": false,
+          "insertionOrder": false,
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "description": "The key name of the tag",
+          "type": "string"
+        },
+        "Value": {
+          "description": "The value for the tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Value",
+        "Key"
+      ]
+    }
+  },
+  "properties": {
+    "propertyA": {
+      "type": "boolean"
+    },
+    "propertyC": {
+      "$ref": "#/definitions/propertyC"
+    }
+  },
+  "primaryIdentifier": [
+    "/properties/propertyA"
+  ],
+  "replacementStrategy": "delete_then_create",
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "/properties/propertyC/Tags",
+    "permissions": [
+      "test:permission"
+    ]
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This code change enhances validation of the `tagProperty`.
1. Validates if there is a correct pointer specified
2. Validates if reference uses correct notation (must start with `/properties/`)
3. Allows tags to be nested properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
